### PR TITLE
Add intermediate tests (as requested by students)

### DIFF
--- a/notebooks/sentencevae/SentVAE.ipynb
+++ b/notebooks/sentencevae/SentVAE.ipynb
@@ -6,7 +6,7 @@
       "name": "SentVAE.ipynb",
       "version": "0.3.2",
       "provenance": [],
-      "collapsed_sections": []
+      "include_colab_link": true
     },
     "kernelspec": {
       "name": "python3",

--- a/notebooks/sentencevae/SentVAE.ipynb
+++ b/notebooks/sentencevae/SentVAE.ipynb
@@ -16,6 +16,16 @@
   },
   "cells": [
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/probabll/dgm4nlp/blob/master/notebooks/sentencevae/SentVAE.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
       "metadata": {
         "colab_type": "code",
         "id": "AcYW7MDKScQ6",

--- a/notebooks/sentencevae/SentVAE.ipynb
+++ b/notebooks/sentencevae/SentVAE.ipynb
@@ -6,7 +6,7 @@
       "name": "SentVAE.ipynb",
       "version": "0.3.2",
       "provenance": [],
-      "include_colab_link": true
+      "collapsed_sections": []
     },
     "kernelspec": {
       "name": "python3",
@@ -15,16 +15,6 @@
     "accelerator": "GPU"
   },
   "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/probabll/dgm4nlp/blob/master/notebooks/sentencevae/SentVAE.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
     {
       "metadata": {
         "colab_type": "code",
@@ -46,7 +36,8 @@
         "import matplotlib.pyplot as plt\n",
         "\n",
         "from torch.utils.data import Dataset, DataLoader\n",
-        "from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence"
+        "from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence\n",
+        "device = torch.device(\"cuda:0\") if torch.cuda.is_available() else torch.device(\"cpu\")"
       ],
       "execution_count": 0,
       "outputs": []
@@ -696,9 +687,6 @@
       },
       "cell_type": "code",
       "source": [
-        "import numpy as np\n",
-        "\n",
-        "\n",
         "class Normal:\n",
         "    \"\"\"\n",
         "    This is a normal distribution\n",
@@ -752,6 +740,119 @@
     },
     {
       "metadata": {
+        "id": "v7N6FU3c2V86",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "# tests for Normal\n",
+        "torch.manual_seed(0xBADF00D)\n",
+        "dummy_loc = torch.randn(10, requires_grad=True)\n",
+        "dummy_scale = torch.linspace(0.1, 5.0, 10, requires_grad=True)\n",
+        "dummy_samples = Normal(dummy_loc, dummy_scale).sample()\n",
+        "sample_pdf = Normal(dummy_loc, dummy_scale).log_pdf(dummy_samples)\n",
+        "\n",
+        "dummy_grads = torch.autograd.grad(dummy_samples.mean(), [dummy_loc, dummy_scale], allow_unused=True)\n",
+        "assert all(grad is not None for grad in dummy_grads), \"samples are not differentiable w.r.t. loc and/or scale. \"\\\n",
+        "                                                      \" Make sure you use torch throughout the implementation \"\n",
+        "assert sample_pdf.shape == dummy_loc.shape\n",
+        "\n",
+        "# kl divergence\n",
+        "dummy_loc_2 = torch.randn(10, requires_grad=True)\n",
+        "\n",
+        "normal1 = Normal(dummy_loc, dummy_scale)\n",
+        "normal2 = Normal(dummy_loc_2, 5.1 - dummy_scale)\n",
+        "dummy_kl = normal1.kl(normal2)\n",
+        "\n",
+        "dummy_kl_ref = torch.tensor([3.423, 1.468, 0.8952, 0.4297, 0.1506, 0.2868, 0.8887, 4.5, 21.904, 1355.1639])\n",
+        "assert dummy_kl.shape == dummy_kl_ref.shape, \"please return a batch of KL divergence with the same shape as self.loc\"\n",
+        "assert torch.allclose(dummy_kl, dummy_kl_ref, rtol=1e-3, atol=1e-3), \"your KL implementation is off\""
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "SsgJqripsmDP",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Then we should implement the inference model $q(z | x, \\lambda)$:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "XUqjJzdXYtMa",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "class InferenceModel(nn.Module):\n",
+        "\n",
+        "    def __init__(self, vocab_size, embedder, hidden_size,\n",
+        "                 latent_size, pad_idx, bidirectional=False):\n",
+        "        \"\"\"\n",
+        "        Implement the layers in the inference model.\n",
+        "        \n",
+        "        :param vocab_size: size of the vocabulary of the language\n",
+        "        :param embedder: embedding layer\n",
+        "        :param hidden_size: size of recurrent cell\n",
+        "        :param latent_size: size D of the latent variable\n",
+        "        :param pad_idx: id of the -PAD- token\n",
+        "        :param bidirectional: whether we condition on x via a bidirectional or \n",
+        "          unidirectional encoder          \n",
+        "        \"\"\"\n",
+        "        pass\n",
+        "\n",
+        "    def forward(self, x, seq_mask, seq_len) -> Normal:\n",
+        "        \"\"\"\n",
+        "        Return an inference Gaussian per instance in the mini-batch\n",
+        "        :param x: sentences [B, T] as token ids\n",
+        "        :param seq_mask: indicates valid positions vs padding positions [B, T]\n",
+        "        :param seq_len: the length of the sequences [B]\n",
+        "        :return: Gaussian approximate posterior\n",
+        "        \"\"\"\n",
+        "        pass"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "dc05nZtd3s9l",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "# tests for inference model\n",
+        "pad_idx = vocab.word_to_idx['<pad>']\n",
+        "\n",
+        "dummy_inference_model = InferenceModel(\n",
+        "    vocab_size=vocab.size(),\n",
+        "    embedder=nn.Embedding(vocab.size(), 64, padding_idx=pad_idx),\n",
+        "    hidden_size=128, latent_size=16, pad_idx=pad_idx, bidirectional=True\n",
+        ").to(device=device)\n",
+        "dummy_batch_size = 32\n",
+        "dummy_dataloader = SortingTextDataLoader(DataLoader(train_dataset, batch_size=dummy_batch_size))\n",
+        "dummy_sentences = next(dummy_dataloader)\n",
+        "\n",
+        "x_in, _, seq_mask, seq_len = create_batch(dummy_sentences, vocab, device)\n",
+        "\n",
+        "q_z_given_x = dummy_inference_model.forward(x_in, seq_mask, seq_len)\n",
+        "assert isinstance(q_z_given_x, Normal), \"inference model should return a Normal distribution\"\n",
+        "assert q_z_given_x.loc.shape == q_z_given_x.scale.shape, \"loc and scale must be of the same size\"\n",
+        "assert q_z_given_x.loc.shape == (dummy_batch_size, 16), \"model must produce [batch_size x latent_size] units.\"\n",
+        "assert torch.all(q_z_given_x.scale >= 0), \"scale can't be negative\""
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
         "id": "EB7rVW7ZsBHP",
         "colab_type": "text"
       },
@@ -771,7 +872,7 @@
         "class BowmanLM(nn.Module):\n",
         "    \n",
         "    def __init__(self, vocab_size, emb_size, hidden_size, latent_size,\n",
-        "                 pad_idx, dropout=0., bidirectional=False):\n",
+        "                 pad_idx, dropout=0.):\n",
         "        \"\"\"\n",
         "        :param vocab_size: size of the vocabulary of the language\n",
         "        :param emb_size: dimensionality of embeddings\n",
@@ -837,54 +938,6 @@
         "        :returns: \n",
         "            negative log likelihood (scalar), KL (scalar)\n",
         "            (use mean for training mode and sum for evaluation mode)\n",
-        "        \"\"\"\n",
-        "        pass"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "SsgJqripsmDP",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Then we should implement the inference model:"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "XUqjJzdXYtMa",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "class InferenceModel(nn.Module):\n",
-        "\n",
-        "    def __init__(self, vocab_size, embedder, hidden_size,\n",
-        "                 latent_size, pad_idx, bidirectional=False):\n",
-        "        \"\"\"\n",
-        "        Implement the layers in the inference model.\n",
-        "        \n",
-        "        :param vocab_size: size of the vocabulary of the language\n",
-        "        :param embedder: embedding layer\n",
-        "        :param hidden_size: size of recurrent cell\n",
-        "        :param latent_size: size D of the latent variable\n",
-        "        :param pad_idx: id of the -PAD- token\n",
-        "        :param bidirectional: whether we condition on x via a bidirectional or \n",
-        "          unidirectional encoder          \n",
-        "        \"\"\"\n",
-        "        pass\n",
-        "\n",
-        "    def forward(self, x, seq_mask, seq_len) -> Normal:\n",
-        "        \"\"\"\n",
-        "        Return an inference Gaussian per instance in the mini-batch\n",
-        "        :param x: sentences [B, T] as token ids\n",
-        "        :param seq_mask: indicates valid positions vs padding positions [B, T]\n",
-        "        :param seq_len: the length of the sequences [B]\n",
-        "        :return: Gaussian approximate posterior\n",
         "        \"\"\"\n",
         "        pass"
       ],
@@ -968,11 +1021,34 @@
     },
     {
       "metadata": {
+        "id": "dNxOoesR4Hh5",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "# test for your BowmanLM implementation with elbo. This may take a few seconds\n",
+        "dummy_lm = BowmanLM(vocab.size(), emb_size=64, hidden_size=128, \n",
+        "                        latent_size=16, pad_idx=pad_idx).to(device=device)\n",
+        "\n",
+        "!head -n 128 {val_file} > ./dummy_dataset\n",
+        "dummy_data = TextDataset('./dummy_dataset')\n",
+        "dummy_rec_loss, dummy_kl = eval_elbo(dummy_lm, dummy_inference_model,\n",
+        "                                     dummy_data, vocab, device)\n",
+        "print(dummy_rec_loss, dummy_kl)\n",
+        "assert dummy_rec_loss.item() > 0 and dummy_kl.item() > 0"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
         "colab_type": "text",
         "id": "tGO7RBYgScR_"
       },
       "cell_type": "markdown",
       "source": [
+        "\n",
         "A common metric to evaluate language models is the perplexity per word. The perplexity per word for a dataset is defined as:\n",
         "\n",
         "\\begin{align}\n",
@@ -1162,7 +1238,6 @@
         "learning_rate = 0.001\n",
         "num_epochs = 20\n",
         "n_importance_samples = 3 # 50\n",
-        "device = torch.device(\"cuda:0\") if torch.cuda.is_available() else torch.device(\"cpu\")   \n",
         "\n",
         "# Create the training data loader.\n",
         "dl = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)\n",


### PR DESCRIPTION
Quick glance: [run in colab](https://colab.research.google.com/github/justheuristic/dgm4nlp/blob/master/notebooks/sentencevae/SentVAE.ipynb#scrollTo=LDD5XF1GScSC)

Proof that it works in colab: [solved notebook](https://colab.research.google.com/drive/1rqolRWeA_RejyWQebKVd_vFtD1DXnlEb)

this code tests intermediate implementations of 
* Normal
* InferenceModel
* BowmanLM

It introduces no changes to the notebook except
* adding "test" cells with a bunch of asserts
* InferenceModel is now implemented _before_ BowmanLM for testing reasons
* device variable is now defined in the first cell